### PR TITLE
Reduce Python version requirement to 3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "timescoring>=0.0.5",
 ]
 readme = "README.md"
-requires-python = ">= 3.12"
+requires-python = ">= 3.11"
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
This has been tested in Python 3.11.3.